### PR TITLE
Change menu scale mode

### DIFF
--- a/src/UI/BaseCraftingMenu.inl
+++ b/src/UI/BaseCraftingMenu.inl
@@ -21,7 +21,7 @@ namespace UI
 			this,
 			uiMovie,
 			GetImpl()->GetMoviePath(),
-			RE::GFxMovieView::ScaleModeType::kNoBorder);
+			RE::GFxMovieView::ScaleModeType::kExactFit);
 		assert(movieLoaded);
 		assert(uiMovie);
 


### PR DESCRIPTION
This is the change they made in 1.6.1130 to supposedly support ultrawide screens. It just makes the menus stretch to fit the whole screen.